### PR TITLE
Fix Version Issues

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 poetry 1.8.3
-python 3.13.1
+python 3.13.5


### PR DESCRIPTION
Test failing with 
```
Current Python version (3.14.2) is not allowed by the project (3.13.5).
Please change python executable via the "env use" command.
WARNING: Requirement './dist/mesh_cli-1.0.0-py3-none-any.whl' looks like a filename, but the file does not exist
``` 
Fix is to update pyhton version to 3.13.5 